### PR TITLE
dependencies trouble

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "aiogram-dialog>=2.0.0",
+    "aiogram-dialog[tools]>=2.0.0",
     "aiogram==3.*",
     "fastapi==0.103.*",
     "uvicorn==0.22.*",


### PR DESCRIPTION
After entering the `aiogram-dialog-preview deseos17.main.bot:get_dispatcher_preview` command, I received an error:

```
Traceback (most recent call last):
  File "/home/alex/.pyenv/versions/deseos17/bin/aiogram-dialog-preview", line 5, in <module>
    from aiogram_dialog.tools.web_preview import main
  File "/home/alex/.pyenv/versions/3.12.2/envs/deseos17/lib/python3.12/site-packages/aiogram_dialog/tools/__init__.py", line 2, in <module>
    from .transitions import render_transitions
  File "/home/alex/.pyenv/versions/3.12.2/envs/deseos17/lib/python3.12/site-packages/aiogram_dialog/tools/transitions.py", line 6, in <module>
    from diagrams import Cluster, Diagram, Edge
ModuleNotFoundError: No module named 'diagrams'
```

This happened because the diagrams dependency is optional in aiogram-dialog. To fix this, I added `aiogram-dialog[tools]` in `pyproject.toml` so that diagrams is installed